### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Usage Example
     display = SSD1331(display_bus, width=96, height=64)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(96, 64, 1)

--- a/examples/ssd1331_simpletest.py
+++ b/examples/ssd1331_simpletest.py
@@ -26,7 +26,7 @@ display_bus = displayio.FourWire(
 display = SSD1331(display_bus, width=96, height=64)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(96, 64, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a SSD1331 display to test with.